### PR TITLE
change documentation links to point to docs.certora.com

### DIFF
--- a/01.Lesson_GettingStarted/README.md
+++ b/01.Lesson_GettingStarted/README.md
@@ -4,7 +4,7 @@
 
 </br>
 
-- [ ] Follow the installation instructions for the Certora Prover described in the following link: [Installation of Certora Prover](https://certora.atlassian.net/wiki/spaces/CPD/pages/7274497/Installation+of+Certora+Prover). 
+- [ ] Follow the installation instructions for the Certora Prover described in the following link: [Installation of Certora Prover](https://docs.certora.com/en/latest/docs/user-guide/getting-started/index.html). 
 
 > :warning: Make sure to download solidity compiler versions 8.7, 8.0, 7.6, 7.5 and 7.0 for the first 2 lessons of the course. You will need additional solc versions in the future; so whenever a solc error will rise, make sure to have the compiler version that you need on your local machine, located in a directory added to PATH.
 

--- a/04.Lesson_Declarations/Methods_Definitions_Functions/README.md
+++ b/04.Lesson_Declarations/Methods_Definitions_Functions/README.md
@@ -25,7 +25,7 @@ In general, creating an arbitrary `env` variable and passing it to the function 
 
 Another reason to declare functions, even if they aren't `envfree`, is to make the specification more self-contained and readable. 
 
-- [ ] Read the documentation on [method declarations](https://certora.atlassian.net/wiki/spaces/CPD/pages/181960777/Method+Declarations) up to "Summary Declarations" (not including). Notice that the documentation refers to things that we haven't learned yet. Don't worry; we will get to it in the future.
+- [ ] Read the documentation on [method declarations](https://docs.certora.com/en/latest/docs/ref-manual/cvl/methods.html) up to "Summary DeclarTypes" (not including). Notice that the documentation refers to things that we haven't learned yet. Don't worry; we will get to it in the future.
 
 This directory contains the three systems from the Lesson 1 Exercise. The interface implementations are the fixed versions (all the rules pass on them out of the box).
 
@@ -43,7 +43,7 @@ This directory contains the three systems from the Lesson 1 Exercise. The interf
 
 Like any other programming language, CVL provides a way to encapsulate code in functions for convenient code reuse.
 
-- [ ] Read the documentation on [CVL functions](https://certora.atlassian.net/wiki/spaces/CPD/pages/238846033/CVL+Functions). 
+- [ ] Read the documentation on [CVL functions](https://docs.certora.com/en/latest/docs/confluence/anatomy/functions.html). 
 
 - [ ] Have a look at the CVL functions in the altered, yet familiar spec from Lesson 1 - `TotalGreaterThenUser`: [BankFixed.sol](LessonExamples/BankFixed.sol) and [Functions_TotalGreaterThenUser.spec](LessonExamples/Functions_TotalGreaterThenUser.spec)
 
@@ -84,7 +84,7 @@ definition C() returns uint256 = 299792458;
 definition meetingUninitialized(uint256 meetingId) returns bool = getStartTimeById(meetingId) == 0 && getEndTimeById(meetingId) == 0 && ...;
 ```
 
-- [ ] Read the documentation on [definitions](https://certora.atlassian.net/wiki/spaces/CPD/pages/41156868/Definitions) up to "Reference Ghost Functions" (not including).
+- [ ] Read the documentation on [definitions](https://docs.certora.com/en/latest/docs/confluence/anatomy/definitions.html) up to "Reference Ghost Functions" (not including).
 
 - [ ] Write the definitions of all the states in the [MeetingScheduler](MeetingScheduler) system.
 

--- a/04.Lesson_Declarations/README.md
+++ b/04.Lesson_Declarations/README.md
@@ -22,7 +22,7 @@
 
 </br>
 
-- [ ] Read the documentation on [Types and Type Handling](https://certora.atlassian.net/wiki/spaces/CPD/pages/7340101/Types) to learn about the different CVL types available to use, their distinction from EVM types, casting operations, and useful macros.
+- [ ] Read the documentation on [Types and Type Handling](https://docs.certora.com/en/latest/docs/ref-manual/cvl/types.html) to learn about the different CVL types available to use, their distinction from EVM types, casting operations, and useful macros.
 
 </br>
 

--- a/05.Lesson_GettingFamiliarWithCVT/README.md
+++ b/05.Lesson_GettingFamiliarWithCVT/README.md
@@ -17,7 +17,7 @@ These scripts flags and features that we still haven't gone through. Try to see 
 
 </br>
 
-- [ ] Have a brief look at the entry on [CLI Options](https://certora.atlassian.net/wiki/spaces/CPD/pages/7340043/Certora+Prover+CLI+Options) in the documentation.
+- [ ] Have a brief look at the entry on [CLI Options](https://docs.certora.com/en/latest/docs/ref-manual/cli/options.html) in the documentation.
 This is where you'll go to learn about additional flags and options. Some of these can help you overcome problems, customize the output to your needs, and make your life much easier.
 We will introduce more specific flags in future lessons when using them help up solve problems.
 

--- a/05.Lesson_GettingFamiliarWithCVT/ScriptExercise2/README.md
+++ b/05.Lesson_GettingFamiliarWithCVT/ScriptExercise2/README.md
@@ -29,7 +29,7 @@ For example:
 certoraRum A.sol:contractA --verify A:parametric.spec --rule integrity --method "foo(uint256, address, bytes32)"
 ```
 
-You can read more about it in the documentation [--method](https://certora.atlassian.net/wiki/spaces/CPD/pages/7340043/Certora+Prover+CLI+Options#--method).
+You can read more about it in the documentation [--method](https://docs.certora.com/en/latest/docs/ref-manual/cli/options.html#method).
 
 </br>
 

--- a/10.Lesson_VacuousRules/README.md
+++ b/10.Lesson_VacuousRules/README.md
@@ -58,7 +58,7 @@ When we fail the newly added assert, the answer to our question is "Yes - there 
 
 When running a verification with the `--rule_sanity` flag, the tool runs the rule/invariant twice - once as written, and again changing the original asserts to requires and adding an `assert false` at the end. It combines the results and indicates whether the `assert false` did not fail, meaning the rule/invariant is empty.
 
-You can read more about the `--rule_sanity` flag in the documentation [Link](https://certora.atlassian.net/wiki/spaces/CPD/pages/7340043/Certora+Prover+CLI+Options#--rule_sanity[inlineExtension])
+You can read more about the `--rule_sanity` flag in the documentation [Link](https://docs.certora.com/en/latest/docs/ref-manual/cli/options.html#rule-sanity)
 
 > :warning: The indication given for `--rule_sanity` at the moment is :warning: over a red background. A better presentation should be integrated soon.
 


### PR DESCRIPTION
The lessons in the tutorial pointed to the old Certora documentation in Confluence. Changed all links to point to docs.certorra.com