### PR TITLE
fixing invariant example

### DIFF
--- a/07.Lesson_InductiveReasoning/Invariants/Bank/invariant.spec
+++ b/07.Lesson_InductiveReasoning/Invariants/Bank/invariant.spec
@@ -37,19 +37,6 @@ rule can_withdraw_attempt() {
         "withdraw must increase sender's ETH balance by `getFunds(sender)`";
 }
 
-rule can_withdraw_1() {
-    env e;
-
-    uint256 balance_before = getEthBalance(e.msg.sender);
-    uint256 reserves       = getEthBalance(currentContract);
-    uint256 funds_before   = getFunds(e.msg.sender);
-
-    withdraw@withrevert(e);
-
-    uint256 balance_after  = getEthBalance(e.msg.sender);
-    assert balance_after == balance_before + funds_before;
-}
-
 invariant totalFunds_GE_single_user_funds()
     // A quantifier is followed by a declaration of a variable to say "for all users, $exp$ should hold"
     // Quantifiers are raising the complexity of of the run by a considerable amount, so often using them will result in a timeout

--- a/07.Lesson_InductiveReasoning/Invariants/Bank/invariant.spec
+++ b/07.Lesson_InductiveReasoning/Invariants/Bank/invariant.spec
@@ -37,10 +37,13 @@ rule can_withdraw_attempt() {
         "withdraw must increase sender's ETH balance by `getFunds(sender)`";
 }
 
-invariant totalFunds_GE_single_user_funds()
-    // A quantifier is followed by a declaration of a variable to say "for all users, $exp$ should hold"
-    // Quantifiers are raising the complexity of of the run by a considerable amount, so often using them will result in a timeout
-    forall address user. getTotalFunds() >= getFunds(user)
+/**
+ * The total funds in the bank is larger than any individual's balance.
+ *
+ * @dev This doesn't pass for technical reasons, see `README.md` for discussion
+ */
+invariant totalFunds_GE_single_user_funds_attempt(address user)
+    getTotalFunds() >= getFunds(user)
 
 /* A declaration of a ghost.
  * A ghost is, in esssence, an uninterpeted function (remember lesson 3?).


### PR DESCRIPTION
There are a few problems with the invariant example in lesson 7: it uses foralls in the invariant, it doesn't loop back and prove the original claim (with requireInvariant), and the rule uses `@withrevert` in an unusual way