### PR TITLE
fix typo in SMTSolver cheatsheet by using correct variable name.

### DIFF
--- a/03.Lesson_SMT/Z3SMTSolver/Cheat_Sheet.md
+++ b/03.Lesson_SMT/Z3SMTSolver/Cheat_Sheet.md
@@ -62,7 +62,7 @@
 	1. And, or, xor, not, => (implication), ite (if-then-else), = (Bi-implications).
 	2. Example:
 	``` 
-	(declare-const q Bool)
+	(declare-const p Bool)
 	(declare-const q Bool)
 	(declare-const r Bool)
 	(define-fun conjecture () Bool


### PR DESCRIPTION
Prior to this commit the z3 example defined 'q' twice, when it should have defined two separate variables 'p' and 'q'.